### PR TITLE
Fix day-of-week mapping for Sunday

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 jQuery plugin.
 
-A silly little ditty that basically sits some 
-classes onto an element depending on the 
+A silly little ditty that basically sits some
+classes onto an element depending on the
 time of day.
 
 Basic use ..
@@ -15,19 +15,19 @@ $('body').chronoClass({
    timeOfDay:false
 });
 
-If it is friday afternoon it will do the following 
+If it is friday afternoon it will do the following
 if you have true set to the options above ..
 
 <body class="fri afternoon"></body>
 
 You can then make it look like a sexy beer
  garden or whatever your ill be.
- 
-Read the code if you need more info, 
-or tell me what you wanna know and 
+
+Read the code if you need more info,
+or tell me what you wanna know and
 I'll write it here you swine.
 
 Seen on http://gofreerange.com/blog
 
-I'd like to thank The Smiths 
+I'd like to thank The Smiths
 for musical accompaniment whilst I wrote it, yeah?

--- a/chronoClass.jQuery.js
+++ b/chronoClass.jQuery.js
@@ -57,8 +57,8 @@
       var now = new Date();
 
       if (o.dayOfWeek) {
-        var dayNames = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
-        $this.addClass(dayNames[now.getDay()-1]);
+        var dayNames = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+        $this.addClass(dayNames[now.getDay()]);
       };
 
       if (o.timeOfDay) {

--- a/chronoClass.jQuery.js
+++ b/chronoClass.jQuery.js
@@ -1,35 +1,35 @@
 /*
  * jQuery ChronoClass Plugin
  * Written by Jase jase@gofreerange.com
- * License: Who cares etc. 
+ * License: Who cares etc.
  *
- * This silly little ditty basically sits some 
- * classes onto an element depending on the 
+ * This silly little ditty basically sits some
+ * classes onto an element depending on the
  * time of day.
- * 
+ *
  * Basic use ..
- * 
+ *
  * $('body').chronoClass();
- * 
+ *
  * You can enable days of week, and period of day ..
- * 
+ *
  * $('body').chronoClass({
  *    dayOfWeek:true,
  *    timeOfDay:false
  * });
- *  
- * Read the code if you need more info, 
- * or tell me what you wanna know and 
+ *
+ * Read the code if you need more info,
+ * or tell me what you wanna know and
  * I'll write it here you swine.
- * 
+ *
  * Seen on http://gofreerange.com/blog
- * 
- * I'd like to thank The Smiths 
+ *
+ * I'd like to thank The Smiths
  * for musical accompaniment whilst I wrote it, yeah?
 */
 
 ;(function($) {
-  
+
   Date.hourToPeriod = function (date) {
     if (!date) { date = new Date() };
     var period;
@@ -43,7 +43,7 @@
     };
     return period;
   }
-  
+
   // What does the chronoClass plugin do?
   $.fn.chronoClass = function(options) {
     var opts = $.extend({}, $.fn.chronoClass.defaults, options);
@@ -55,12 +55,12 @@
       var o = $.meta ? $.extend({}, opts, $this.data()) : opts;
 
       var now = new Date();
-      
+
       if (o.dayOfWeek) {
         var dayNames = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
         $this.addClass(dayNames[now.getDay()-1]);
       };
-      
+
       if (o.timeOfDay) {
         $this.addClass(Date.hourToPeriod(now));
       };


### PR DESCRIPTION
[`Date.prototype.getDay()`][1] returns 0 for Sunday. Thus previously on Sundays the `dayNames` array lookup returned `undefined` and no CSS class was added to the element.

By moving Sunday (`'sun'`) to the beginning of `dayNames` and using the `getDay()` index directly we can fix the problem so that a `'sun'` CSS class is correctly added to the element.

Ideally I would've added some tests, but given that I'm not sure we're going to want to continue to use this plugin and I would need to setup the whole testing infrastructure for the project, I've decided it's not worth it at the moment!

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay